### PR TITLE
Add support for dynamically determining Oracle Primary and Secondary Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,11 @@ The user for the Delphix DDP to login to the system
     user_comment: "Delphix Automation"
 Comment for the user
 
-    delphix_group: delphix
-The group to which delphix_user should belong
+    delphix_primary_group: delphix
+The primary group to which delphix_user should belong
+
+    delphix_secondary_group: []
+List of secondary groups to which delphix_user should belong
 
     delphix_home: "/home/{{ delphix_user }}"
 The home of the delphix_user

--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@ platform. This includes installing all required packages, and creating a
 most notably managing NFS mounts.  The resulting host can be used with a
 standard username, directories, and SSH key access.
 
-The role provides a mechanism for configuring the `delphix` user with a single
-engine public SSH key in `/home/delphix/.ssh/authorized_keys`. In the event
+If the variable `install_oracle` to `true` this role will perform Oracle specific
+setup tasks:  setting `delphix` user to have the same groups as Oracle and
+performing `g+w` on the Oracle Homes. 
+
+The role provides a mechanism for configuring the `delphix` user with multiple 
+public SSH keys in `/home/delphix/.ssh/authorized_keys`. In the event
 that you are building a cloud image and want to configure the SSH key at
 runtime, you can use cloud init (as described for AWS
 [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html)) to
@@ -40,6 +44,10 @@ This role is automatically tested on a weekly basis for the following OS:
 
 Available variables are listed below, along with default values (see defaults/main.yml).
 There is also a sample group_vars directory with common settings for specific target types, like oracletargets.
+Note that setting `delphix_primary_group` and/or `delphix_secondary_groups` at either the playbook or 
+command line (with `-e`) will override the action of dynamically determining these from the Oracle 
+Home owner (typically `oracle`).  Typically it would not make sense to set these at such a high level
+if you also set `install_oracle=true`.
 
     delphix_user: delphix
 The user for the Delphix DDP to login to the system
@@ -63,7 +71,7 @@ The directory where the Delphix DDP should mount the VDBs
 The directory where the Delphix DDP will store the toolkit files
 
     delphix_ssh_keys: {}
-Optional: The SSH key of the Delphix DDP
+Optional: The SSH key(s) of the Delphix DDP
 
 Here's an example using delphix_ssh_keys to add a Delphix DDP public key to a host:
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Delphix Target Host
 
 ## <a id="overview"></a>Overview
 
-This role will configure a Linux system for use as a target host in the Delphix
-platform. This includes installing all required packages, and creating a
-`delphix` user with sufficient sudo privileges support all platform operations,
+This role will configure a Linux system for use as a target host for the Delphix
+platform. This includes installing all required packages and creating a
+`delphix` user with sufficient sudo privileges to support all platform operations,
 most notably managing NFS mounts.  The resulting host can be used with a
 standard username, directories, and SSH key access.
 
-If the variable `install_oracle` to `true` this role will perform Oracle specific
-setup tasks:  setting `delphix` user to have the same groups as Oracle and
-performing `g+w` on the Oracle Homes. 
+If the variable `install_oracle` is set to `true`, this role will also perform 
+Oracle specific setup tasks:  setting `delphix` user to have the same groups as 
+Oracle user and performing `g+w` on the Oracle Home `dbs` directory. 
 
 The role provides a mechanism for configuring the `delphix` user with multiple 
 public SSH keys in `/home/delphix/.ssh/authorized_keys`. In the event
@@ -46,7 +46,7 @@ Available variables are listed below, along with default values (see defaults/ma
 There is also a sample group_vars directory with common settings for specific target types, like oracletargets.
 Note that setting `delphix_primary_group` and/or `delphix_secondary_groups` at either the playbook or 
 command line (with `-e`) will override the action of dynamically determining these from the Oracle 
-Home owner (typically `oracle`).  Typically it would not make sense to set these at such a high level
+Home owner (typically `oracle`).  Usually it would not make sense to set these at such a high level
 if you also set `install_oracle=true`.
 
     delphix_user: delphix

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,8 +15,10 @@ os_min_supported_version: "{% if ansible_os_family == 'Suse' %}11{% else %}6.3{%
 delphix_user: delphix
 ### Comment for the user
 user_comment: "Delphix Automation"
-### The group to which delphix_user should belong
-delphix_group: delphix
+### The primary group to which delphix_user should belong
+delphix_primary_group: delphix
+### The secondary groups to which delphix_user should belong
+delphix_secondary_groups: []
 ### The home of the delphix_user
 delphix_home: "/home/{{ delphix_user }}"
 ### The directory where the Delphix DDP should mount the VDBs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ delphix_toolkit: /home/delphix/toolkit
 # ex.
 #  delphix_ssh_keys:
 #   - name: DE1
+# yamllint disable-line rule:line-length
 #     key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYCptAFSoJwnHVgCX5xC2c5W9unRbFen5PvUasQ8tnlouNRte5hnKe10bgkMFN4LSUbXggXk1C+9eMMKvpKxifFFLVTNCtKGyBsrUpmKLWAoQU5ycpXFfGmgtASJn+VZh5VYbCKTcvVsadR8UA7PyOU6V5gayELKZBczw7gvpaGyM4cF4/1VqK7UzbnEXe0Rt3xozYMC+xyRSk+RZTh+grHYHb1Q/0cSsQmaw1sTlIFl8BAjXNMEmPoCISfSpO4F3yWmJUIEPtkWHWiKOUzgoi20vnvZnLHd54NAE8F+aJn4eNarAn0x2XWUdmgLuAM/7KzF5kn0+k9Pm3iJ1jE14J root@ip-10-0-1-10"
 delphix_ssh_keys: {}
 # Allowed sudo commands for the delphix_user

--- a/molecule/default/yaml-lint.yml
+++ b/molecule/default/yaml-lint.yml
@@ -12,7 +12,13 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
-  line-length: disable
-  # NOTE(retr0h): Templates no longer fail this lint rule.
-  #               Uncomment if running old Molecule templates.
-  # truthy: disable
+  # Better to warn if longer than 160, as Ansible Galaxy will penalize this
+  # You can mark intentional long lines like this:
+  # This line is waaaaaaaaaay too long  # yamllint disable-line rule:line-length
+  #   line-length: disable
+  line-length:
+    max: 160
+    level: warning
+# NOTE(retr0h): Templates no longer fail this lint rule.
+#               Uncomment if running old Molecule templates.
+# truthy: disable

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,10 +30,6 @@
       - existing_dbhome is defined
   when: install_oracle
 
-#- name: Set delphix group if this is an Oracle Install
-#  set_fact:
-#    delphix_primary_group: {{ existing_dbhome_owner_getent.results.item[0].stat.
-
 # Setup/install tasks.
 - include_tasks: setup-{{ ansible_os_family }}.yml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,21 @@
     packages: "{{ __packages | list }}"
   when: packages is not defined
 
+- name: Set Oracle Variables
+  include_tasks: oracle_vars.yml
+  when: install_oracle
+
+- name: Check for Oracle Installation in place
+  assert:
+    that:
+      - oraInst is defined
+      - existing_dbhome is defined
+  when: install_oracle
+
+#- name: Set delphix group if this is an Oracle Install
+#  set_fact:
+#    delphix_primary_group: {{ existing_dbhome_owner_getent.results.item[0].stat.
+
 # Setup/install tasks.
 - include_tasks: setup-{{ ansible_os_family }}.yml
 
@@ -141,5 +156,5 @@
 # Include Oracle specific tasks if install_oracle=true
 #
 
-- include_tasks: "oracle.yml"
+- include_tasks: "ohome-group-write.yml"
   when: install_oracle

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,22 +25,28 @@
 #
 # Configure the 'delphix' user and home directory
 #
-- name: Add Delphix group
+- name: Add Delphix primary group
   group:
-    name: "{{ delphix_group }}"
+    name: "{{ delphix_primary_group }}"
+
+- name: Add Delphix secondary groups
+  group:
+    name: "{{ item }}"
+  loop: "{{ delphix_secondary_groups }}"
 
 - name: Add Delphix user
   user:
     name: "{{ delphix_user }}"
     home: "{{ delphix_home }}"
-    group: "{{ delphix_group }}"
+    group: "{{ delphix_primary_group }}"
+    groups: "{{ delphix_secondary_groups }}"
     comment: "{{ user_comment }}"
 
 - name: Create delphix directories
   file:
     path: "{{ item.path }}"
     owner: "{{ delphix_user }}"
-    group: "{{ delphix_group }}"
+    group: "{{ delphix_primary_group }}"
     mode: "{{ item.mode }}"
     state: directory
   with_items:
@@ -57,7 +63,7 @@
   file:
     path: "{{ delphix_home }}/.ssh/authorized_keys"
     owner: "{{ delphix_user }}"
-    group: "{{ delphix_group }}"
+    group: "{{ delphix_primary_group }}"
     mode: 0600
     state: "{{ 'file' if ak.stat.exists else 'touch' }}"
 

--- a/tasks/ohome-group-write.yml
+++ b/tasks/ohome-group-write.yml
@@ -2,29 +2,6 @@
 # Set Group Write Permissions on ORACLE_HOME/dbs for all installed ORACLE_HOMEs
 # Executed only if delphix_user is not equal to "oracle"
 
-- name: Find inventory
-  shell: cat /etc/oraInst.loc | grep inventory_loc | awk -F"=" '{print $2}'
-  register: oraInst
-
-- debug:
-    msg: "{{ oraInst.stdout }}"
-    verbosity: 2
-
-- name: Parse inventory
-  shell: cat "{{ oraInst.stdout }}/ContentsXML/inventory.xml" |grep "HOME NAME" | grep -vi "CRS=" | grep -vi "REMOVED=" | awk '{print $3}' | awk -F"=" '{print $2}'  | tr -d '"'
-  register: existing_dbhome
-
-- debug:
-    msg: "Found ORACLE_HOME - {{ item }}"
-    verbosity: 2
-  with_items: "{{ existing_dbhome.stdout_lines }}"
-
-- name: Check owner of oracle executable
-  stat:
-    path: "{{ item }}/bin/oracle"
-  loop: "{{ existing_dbhome.stdout_lines }}"
-  register: existing_dbhome_with_owner
-
 - name: Setting Group Permission on ORACLE_HOME/dbs
   file:
     path: "{{ item.item }}/dbs"

--- a/tasks/oracle.yml
+++ b/tasks/oracle.yml
@@ -1,6 +1,0 @@
----
-# These tasks are only executed for Oracle Targets
-
-# Set Group Write Permissions on ORACLE_HOME/dbs for all installed ORACLE_HOMEs
-
-- include_tasks: ohome-group-write.yml

--- a/tasks/oracle_vars.yml
+++ b/tasks/oracle_vars.yml
@@ -38,7 +38,7 @@
 
 - name: Set Variable oracle_owner
   set_fact:
-   oracle_owner: "{{ existing_dbhome_with_owner.results | map(attribute='stat') | map(attribute='pw_name') | unique | join(', ')  }}"
+    oracle_owner: "{{ existing_dbhome_with_owner.results | map(attribute='stat') | map(attribute='pw_name') | unique | join(', ')  }}"
 
 - name: Get(ent) password file entry for oracle_owner
   getent:
@@ -62,7 +62,7 @@
   set_fact:
     delphix_primary_gid: "{{ getent_passwd[oracle_owner][2] }}"
 
-#Note that if this is set at the playbook or command line (-e) level, it will take priority!
+# Note that if this is set at the playbook or command line (-e) level, it will take priority!
 - name: Set fact delphix_primary_group
   set_fact:
     delphix_primary_group: "{{ (getent_group | dict2items | selectattr('value.1','search',delphix_primary_gid) | list | first).key  }}"
@@ -73,9 +73,8 @@
 
 - name: Set fact delphix_secondary_groups
   set_fact:
-     delphix_secondary_groups: "{{ getent_group | dict2items | selectattr('value.2','search','oracle') | map(attribute='key') |  reject('==',delphix_primary_group) | list }}"
+    delphix_secondary_groups: "{{ getent_group | dict2items | selectattr('value.2','search','oracle') | map(attribute='key') |  reject('==',delphix_primary_group) | list }}"
 
 - debug:
     msg: "delphix_secondary_groups: {{ delphix_secondary_groups }}"
     verbosity: 2
-

--- a/tasks/oracle_vars.yml
+++ b/tasks/oracle_vars.yml
@@ -1,0 +1,81 @@
+---
+# Determine oraInst.loc, Existing DB Homes, DB Home owner (typically "oracle" user), and DB Home owner groups
+
+- name: Read and Parse oraInst.loc
+  shell: cat /etc/oraInst.loc | grep inventory_loc | awk -F"=" '{print $2}'
+  register: oraInst
+
+- debug:
+    msg: "oraInst.stdout: {{ oraInst.stdout }}"
+    verbosity: 2
+
+- name: Read and Parse inventory.xml
+  shell: cat "{{ oraInst.stdout }}/ContentsXML/inventory.xml" |grep "HOME NAME" | grep -vi "CRS=" | grep -vi "REMOVED=" | awk '{print $3}' | awk -F"=" '{print $2}'  | tr -d '"'
+  register: existing_dbhome
+
+- debug:
+    msg: "existing_dbhome.stdout_lines.item: {{ item }}"
+    verbosity: 2
+  with_items: "{{ existing_dbhome.stdout_lines }}"
+
+- name: Get owner(s) of oracle executable
+  stat:
+    path: "{{ item }}/bin/oracle"
+  loop: "{{ existing_dbhome.stdout_lines }}"
+  register: existing_dbhome_with_owner
+
+- debug:
+    msg:
+      - "existing_dbhome_with_owner.results.0.stat.pw_name: {{ existing_dbhome_with_owner.results.0.stat.pw_name }}"
+      - "list of pw_name: {{ existing_dbhome_with_owner.results | map(attribute='stat') | map(attribute='pw_name') | list | join(', ') }}"
+    verbosity: 2
+
+- name: Check that there is only one oracle user on this machine
+  assert:
+    that:
+      - "{{ existing_dbhome_with_owner.results | map(attribute='stat') | map(attribute='pw_name') | unique | count }} == 1"
+    fail_msg: "This script only works with 1 oracle user per machine, owning 1 or more Oracle Homes"
+
+- name: Set Variable oracle_owner
+  set_fact:
+   oracle_owner: "{{ existing_dbhome_with_owner.results | map(attribute='stat') | map(attribute='pw_name') | unique | join(', ')  }}"
+
+- name: Get(ent) password file entry for oracle_owner
+  getent:
+    database: passwd
+    key: "{{ oracle_owner }}"
+
+- debug:
+    msg: "getent_passwd: {{ getent_passwd }}"
+    verbosity: 2
+
+- name: Get(ent) groups
+  getent:
+    database: group
+    split: ':'
+
+- debug:
+    msg: "getent_group: {{ getent_group }}"
+    verbosity: 2
+
+- name: Set fact delphix_primary_gid
+  set_fact:
+    delphix_primary_gid: "{{ getent_passwd[oracle_owner][2] }}"
+
+#Note that if this is set at the playbook or command line (-e) level, it will take priority!
+- name: Set fact delphix_primary_group
+  set_fact:
+    delphix_primary_group: "{{ (getent_group | dict2items | selectattr('value.1','search',delphix_primary_gid) | list | first).key  }}"
+
+- debug:
+    msg: "delphix_primary_group: {{ delphix_primary_group }}"
+    verbosity: 2
+
+- name: Set fact delphix_secondary_groups
+  set_fact:
+     delphix_secondary_groups: "{{ getent_group | dict2items | selectattr('value.2','search','oracle') | map(attribute='key') |  reject('==',delphix_primary_group) | list }}"
+
+- debug:
+    msg: "delphix_secondary_groups: {{ delphix_secondary_groups }}"
+    verbosity: 2
+

--- a/tasks/oracle_vars.yml
+++ b/tasks/oracle_vars.yml
@@ -2,16 +2,32 @@
 # Determine oraInst.loc, Existing DB Homes, DB Home owner (typically "oracle" user), and DB Home owner groups
 
 - name: Read and Parse oraInst.loc
-  shell: cat /etc/oraInst.loc | grep inventory_loc | awk -F"=" '{print $2}'
+  shell: |
+    set -o pipefail
+    cat /etc/oraInst.loc | grep inventory_loc | awk -F"=" '{print $2}'
   register: oraInst
+  args:
+    executable: /bin/bash
+  changed_when: false
 
 - debug:
     msg: "oraInst.stdout: {{ oraInst.stdout }}"
     verbosity: 2
 
 - name: Read and Parse inventory.xml
-  shell: cat "{{ oraInst.stdout }}/ContentsXML/inventory.xml" |grep "HOME NAME" | grep -vi "CRS=" | grep -vi "REMOVED=" | awk '{print $3}' | awk -F"=" '{print $2}'  | tr -d '"'
+  shell: >-
+    set -o pipefail &&
+    cat "{{ oraInst.stdout }}/ContentsXML/inventory.xml" |
+    grep "HOME NAME" |
+    grep -vi "CRS=" |
+    grep -vi "REMOVED=" |
+    awk '{print $3}' |
+    awk -F"=" '{print $2}'  |
+    tr -d '"'
   register: existing_dbhome
+  args:
+    executable: /bin/bash
+  changed_when: false
 
 - debug:
     msg: "existing_dbhome.stdout_lines.item: {{ item }}"
@@ -73,8 +89,13 @@
 
 - name: Set fact delphix_secondary_groups
   set_fact:
-    delphix_secondary_groups: "{{ getent_group | dict2items | selectattr('value.2','search','oracle') | map(attribute='key') |  reject('==',delphix_primary_group) | list }}"
-
+    delphix_secondary_groups: >-
+      {{ getent_group | dict2items | selectattr('value.2','search','oracle') |
+      map(attribute='key') |  reject('==',delphix_primary_group) | list }}
 - debug:
     msg: "delphix_secondary_groups: {{ delphix_secondary_groups }}"
     verbosity: 2
+
+# - name: Break Point
+#   assert:
+#     that: 1==2

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -5,7 +5,11 @@
 ---
 
 - name: Check if 32-bit runtime is installed
-  shell: dpkg --print-foreign-architectures | grep i386
+  shell: |
+    set -o pipefail
+    dpkg --print-foreign-architectures | grep i386
+  args:
+    executable: /bin/bash
   register: result_32bit
   changed_when: result_32bit.rc == 1
   failed_when: result_32bit.rc > 1


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [x] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: 7
Currently does not allow primary and secondary group setting.
Currently does not dynamically determine Oracle user primary and secondary groups


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Allows Primary and Secondary Group 
- Dynamically determines Oracle user primary and secondary groups
- Improve README, yamllint and ansible-lint scores

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
